### PR TITLE
Add grid dashboard and theme toggle

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -73,5 +73,6 @@
     <!-- Scripts -->
     <script src="{{ '/javascript/javaventuraayayay.js' | relative_url }}"></script>
     <script src="{{ '/javascript/side-title.js' | relative_url }}"></script>
+    <script src="{{ '/javascript/theme-toggle.js' | relative_url }}"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -43,18 +43,19 @@ layout: default
         
         /* Index layout */
         .index-main-layout {
-            display: flex;
-            flex-wrap: wrap;
+            display: grid;
+            grid-template-columns: 1fr 2fr;
             gap: var(--space-l);
             margin-top: var(--space-xl);
         }
 
         .index-left {
-            flex: 1 1 300px;
+            padding-right: var(--space-l);
+            border-right: 1px dotted var(--color-border);
         }
 
         .index-right {
-            flex: 1 1 300px;
+            padding-left: var(--space-l);
         }
 
         .post-list {
@@ -97,7 +98,7 @@ layout: default
 
         @media (max-width: 768px) {
             .index-main-layout {
-                flex-direction: column;
+                grid-template-columns: 1fr;
             }
 
             .index-right {
@@ -135,6 +136,7 @@ layout: default
                 <div class="dotted-box">
                     <p><span class="dropcap">I</span>write about rationality, mundane utility, and our gloriously apollonian expansion into the lightcone. Earth is currently under siege: chiefly <a href="https://en.wikipedia.org/wiki/Existential_risk_from_AI">this</a> but also <a href="https://en.wikipedia.org/wiki/Death">this</a> and even <a href="https://en.wikipedia.org/wiki/List_of_cognitive_biases">this</a>. I'm active here, <a href="https://lesswrong.com/users/croissanthology">LessWrong</a>, and <a href="https://x.com/croissanthology">Twitter.</a></p>
                     <p>You can email me at croissanthology [at] gmail.com. If you think I'd use your money wisely I have a <a href="https://www.patreon.com/cleoscrolls">Patreon</a>. All my writing is <a href="https://croissanthology.com/all">here</a>. I might start with <a href= "https://croissanthology.com/tactics" >this</a> or <a href= "https://croissanthology.com/allowed">this</a>. There is a newsletter; scroll all the way down to find it.</p>
+                    <p>Switch to <a href="#" id="toggle-dark">dark mode</a>, <a href="#" id="toggle-system">system</a>.</p>
                 </div>
             </div>
 

--- a/javascript/theme-toggle.js
+++ b/javascript/theme-toggle.js
@@ -1,0 +1,36 @@
+document.addEventListener('DOMContentLoaded', () => {
+    const darkLink = document.getElementById('toggle-dark');
+    const systemLink = document.getElementById('toggle-system');
+
+    function applyTheme(theme) {
+        if (theme === 'system') {
+            const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+            document.documentElement.setAttribute('data-theme', prefersDark ? 'dark' : 'light');
+        } else {
+            document.documentElement.setAttribute('data-theme', theme);
+        }
+    }
+
+    function setTheme(theme) {
+        localStorage.setItem('theme', theme);
+        applyTheme(theme);
+    }
+
+    const saved = localStorage.getItem('theme') || 'light';
+    applyTheme(saved);
+
+    if (darkLink) {
+        darkLink.addEventListener('click', (e) => {
+            e.preventDefault();
+            const current = document.documentElement.getAttribute('data-theme') === 'dark' ? 'light' : 'dark';
+            setTheme(current);
+        });
+    }
+
+    if (systemLink) {
+        systemLink.addEventListener('click', (e) => {
+            e.preventDefault();
+            setTheme('system');
+        });
+    }
+});


### PR DESCRIPTION
## Summary
- convert dashboard layout to grid and add dotted divider
- add dark mode toggle links and supporting script
- wire theme script into main layout

## Testing
- `node -v`
- _No other tests run due to environment limitations_

------
https://chatgpt.com/codex/tasks/task_e_6857fdd460dc8321b56169c19aadab0b