### PR TITLE
Update dashboard styling

### DIFF
--- a/CSS/styles.css
+++ b/CSS/styles.css
@@ -41,7 +41,7 @@ body, h1, h2, h3, h4, h5, h6, p, figure, blockquote, dl, dd {
     --font-body: var(--font-system);
     
     /* Sizing */
-    --content-width: min(800px, 90vw);
+    --content-width: min(1000px, 95vw);
     --line-height: 1.6;
     
     /* Z-index scale */
@@ -56,7 +56,8 @@ body, h1, h2, h3, h4, h5, h6, p, figure, blockquote, dl, dd {
     --color-bg: #f5f5f5;
     --color-text: #333333;
     --color-heading: #000000;
-    --color-accent: #2a5c3d;
+    /* Lighter accent for light mode */
+    --color-accent: #6fb88a;
     --color-link: #333333;
     --color-muted: #666666;
     --color-border: #cccccc;
@@ -357,7 +358,7 @@ li {
 /* Title */
 .title-container {
     text-align: center;
-    margin: var(--space-xl) 0;
+    margin: var(--space-l) 0;
     position: relative;
     height: 100px;
     overflow: hidden;
@@ -379,7 +380,7 @@ li {
 }
 
 .title-white {
-    color: white;
+    color: var(--color-heading);
 }
 
 .title-green {

--- a/index.html
+++ b/index.html
@@ -37,16 +37,16 @@ layout: default
         }
         
         :root {
-            --main-width: min(800px, 90vw);
+        --main-width: min(1000px, 95vw);
             --padding-left: 20px;
         }
         
         /* Index layout */
         .index-main-layout {
             display: grid;
-            grid-template-columns: 1fr 2fr;
+            grid-template-columns: 1fr 3fr;
             gap: var(--space-l);
-            margin-top: var(--space-xl);
+            margin-top: var(--space-l);
         }
 
         .index-left {
@@ -70,10 +70,15 @@ layout: default
         .post-list a {
             color: var(--color-link);
             text-decoration: none;
+            position: relative;
+            display: inline-block;
+            border-bottom: 1px dotted currentColor;
+            transition: color 0.2s ease, border-color 0.2s ease;
         }
 
         .post-list a:hover {
-            text-decoration: underline;
+            color: var(--color-accent);
+            border-bottom-style: solid;
         }
 
         .featured-post {
@@ -117,8 +122,7 @@ layout: default
         <h6 class="mobile-header-title">Croissanthology</h6>
         <div class="progress-bar"></div>
     </div> 
-    
-          <br><br>
+
 
     <div class="content-wrapper">
         <div class="index-main-layout">


### PR DESCRIPTION
## Summary
- enlarge content width and lighten accent in light mode
- adjust title colors and positioning
- give post preview links same styling as body links
- tweak layout spacing

## Testing
- `jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858807e6ccc832194a941138cecc1ea