### PR TITLE
Refine front page layout and styles

### DIFF
--- a/CSS/styles.css
+++ b/CSS/styles.css
@@ -258,22 +258,22 @@ a[href*="x.com"]:hover {
 /* First paragraph drop cap */
 .dropcap {
     font-family: var(--font-display);
-    font-size: 4em;
+    font-size: 6em;
     font-weight: 200;
-    line-height: 0.8;
+    line-height: 0.65;
     float: left;
-    margin: 0.1em 0.1em 0 0;
+    margin: 0.2em 0.2em 0 0;
     color: var(--color-accent);
 }
 
 /* First paragraph in post content */
 .post-content > p:first-of-type:first-letter {
     font-family: var(--font-display);
-    font-size: 4em;
+    font-size: 6em;
     font-weight: 200;
-    line-height: 0.8;
+    line-height: 0.65;
     float: left;
-    margin: 0.1em 0.1em 0 0;
+    margin: 0.2em 0.2em 0 0;
     color: var(--color-accent);
 }
 
@@ -372,11 +372,12 @@ li {
     margin: 0;
     position: relative;
     z-index: 2;
-    font-family: var(--font-display);
-    font-weight: 300;
+    font-family: 'Poiret One', cursive;
+    font-weight: 200;
     text-transform: uppercase;
     letter-spacing: 0.2em;
     transition: opacity 0.3s ease;
+    visibility: hidden;
 }
 
 .title-white {

--- a/index.html
+++ b/index.html
@@ -27,6 +27,8 @@ layout: default
           font-family: 'Inter', sans-serif !important;
           border-radius: 0 !important;
           border: 1px solid #404040 !important;
+          background-color: var(--color-bg) !important;
+          color: var(--color-text) !important;
         }
 
         #custom-substack-embed button {
@@ -34,6 +36,8 @@ layout: default
           letter-spacing: 2px !important;
           text-transform: uppercase !important;
           border-radius: 4px !important;
+          background-color: var(--color-accent) !important;
+          color: var(--color-heading) !important;
         }
         
         :root {
@@ -44,7 +48,7 @@ layout: default
         /* Index layout */
         .index-main-layout {
             display: grid;
-            grid-template-columns: 1fr 3fr;
+            grid-template-columns: 1fr 4fr;
             gap: var(--space-l);
             margin-top: var(--space-l);
         }
@@ -64,7 +68,7 @@ layout: default
         }
 
         .post-list li {
-            margin-bottom: var(--space-s);
+            margin-bottom: var(--space-xs);
         }
 
         .post-list a {
@@ -129,7 +133,7 @@ layout: default
             <div class="index-left">
                 <div class="title-container">
                     <h1 class="title">
-                        <span class="title-white" style="font-family: 'Poiret One', cursive;">Croiss</span><span class="title-green">anthology</span>
+                        <span class="title-white">Croiss</span><span class="title-green">anthology</span>
                     </h1>
                     <div class="shine-effect"></div>
                     <div class="image-replacement">
@@ -145,12 +149,12 @@ layout: default
             </div>
 
             <div class="index-right">
-                <h2>Recent Posts</h2>
                 <ul class="post-list">
                 {% for post in site.posts limit:5 %}
                     <li><a href="{{ post.url }}">{{ post.title }}</a></li>
                 {% endfor %}
                 </ul>
+                <div id="custom-substack-embed"></div>
             </div>
         </div>
 
@@ -160,10 +164,6 @@ layout: default
         </div>
 </div>
 
-<!-- Substack embed at the bottom after all posts -->
-<div class="content-wrapper" style="margin-top: 40px; margin-bottom: 40px;">
-  <div id="custom-substack-embed"></div>
-</div>
 
 <!-- Place substack script before closing body tag -->
 <script>
@@ -173,10 +173,7 @@ window.CustomSubstackWidget = {
   buttonText: "Subscribe",
   theme: "custom",
   colors: {
-    primary: "#4A9C6D",
-    input: "#1a1a1a",
-    email: "#e0e0e0",
-    text: "#ffffff"
+    primary: "#4A9C6D"
   }
 };
 </script>

--- a/javascript/javaventuraayayay.js
+++ b/javascript/javaventuraayayay.js
@@ -47,5 +47,10 @@ document.addEventListener('DOMContentLoaded', () => {
         // Your TOC code here
     }
 
-
-
+    // ===== Show title after fonts load =====
+    const mainTitle = document.querySelector('.title');
+    if (mainTitle) {
+        document.fonts.ready.then(() => {
+            mainTitle.style.visibility = 'visible';
+        });
+    }


### PR DESCRIPTION
## Summary
- adjust index layout so the post column is wider and remove the "Recent Posts" heading
- move the newsletter signup inside the posts column and style it for light/dark themes
- use Poiret One for the main title and hide it until fonts load
- enlarge the dropcap so it spans about three lines

## Testing
- `jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685886e726488321900b3e528b9ecf4a