### PR TITLE
Apply dark theme defaults and tweak layout

### DIFF
--- a/CSS/styles.css
+++ b/CSS/styles.css
@@ -37,7 +37,7 @@ body, h1, h2, h3, h4, h5, h6, p, figure, blockquote, dl, dd {
     
     /* Typography */
     --font-system: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
-    --font-display: var(--font-system);
+    --font-display: 'Poiret One', cursive;
     --font-body: var(--font-system);
     
     /* Sizing */
@@ -377,7 +377,7 @@ li {
     text-transform: uppercase;
     letter-spacing: 0.2em;
     transition: opacity 0.3s ease;
-    visibility: hidden;
+    visibility: visible;
 }
 
 .title-white {
@@ -439,7 +439,7 @@ li {
 
 /* Dotted box */
 .dotted-box {
-    margin: var(--space-xl) 0;
+    margin: var(--space-m) 0;
     padding: var(--space-m);
     border: 1px dotted var(--color-muted);
 }

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" data-theme="dark">
 <head> 
     <!-- Fonts -->
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500&display=swap" rel="stylesheet">

--- a/index.html
+++ b/index.html
@@ -150,7 +150,7 @@ layout: default
 
             <div class="index-right">
                 <ul class="post-list">
-                {% for post in site.posts limit:5 %}
+                {% for post in site.posts limit:10 %}
                     <li><a href="{{ post.url }}">{{ post.title }}</a></li>
                 {% endfor %}
                 </ul>

--- a/javascript/theme-toggle.js
+++ b/javascript/theme-toggle.js
@@ -16,7 +16,7 @@ document.addEventListener('DOMContentLoaded', () => {
         applyTheme(theme);
     }
 
-    const saved = localStorage.getItem('theme') || 'light';
+    const saved = localStorage.getItem('theme') || 'dark';
     applyTheme(saved);
 
     if (darkLink) {


### PR DESCRIPTION
## Summary
- set Poiret One as heading font and show site title by default
- reduce spacing before the about section
- switch to dark theme by default
- display 10 recent posts on index

## Testing
- `bundle exec jekyll build` *(fails: Could not locate Gemfile or .bundle/ directory)*

------
https://chatgpt.com/codex/tasks/task_e_685888d6f9508321a10498a203265164