### PR TITLE
UI tweaks and theme improvements

### DIFF
--- a/CSS/styles.css
+++ b/CSS/styles.css
@@ -168,25 +168,23 @@ p {
    ========================================================= */
 
 /* Only apply underlines to content links */
+
+/* Content links with dotted underline */
 .post-content a,
 .dotted-box a {
     color: var(--color-link);
-    text-decoration: none;
-    position: relative;
-    display: inline-block; /* prevent underline bleeding */
-    
-    /* Dotted underline via border */
-    border-bottom: 1px dotted currentColor;
-    
-    /* Smooth transitions */
-    transition: color 0.2s ease, border-color 0.2s ease;
+    text-decoration-line: underline;
+    text-decoration-style: dotted;
+    text-decoration-thickness: 1px;
+    text-underline-offset: 2px;
+    transition: color 0.2s ease;
 }
 
 /* Hover state for content links */
 .post-content a:hover,
 .dotted-box a:hover {
     color: var(--color-accent);
-    border-bottom-style: solid;
+    text-decoration-style: solid;
 }
 
 /* All other links - no underlines by default */
@@ -576,6 +574,10 @@ body.index h4::after,
 body.index h5::after,
 body.index h6::after {
     display: none;
+}
+
+body.index footer {
+    margin-top: calc(var(--space-2xl) + 5vh);
 }
 
 .text-center { text-align: center; }

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" data-theme="dark">
+<html lang="en">
 <head> 
     <!-- Fonts -->
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500&display=swap" rel="stylesheet">

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -27,7 +27,7 @@ layout: default
 
 .post-title {
     font-family: var(--font-display);  /* system font like front page */
-    color: #ffffff;
+    color: var(--color-heading);
     letter-spacing: 0.15em;  /* matching front page headings */
     text-transform: uppercase;
     margin-bottom: 0.8em;
@@ -128,7 +128,7 @@ label.margin-toggle {
     background: rgba(255, 255, 255, 0.03);
     border-left: 3px solid #4A9C6D;
     font-style: normal;
-    color: #d3d3d3;
+    color: var(--color-blockquote);
     font-size: 1.1rem;
 }
 

--- a/index.html
+++ b/index.html
@@ -73,16 +73,16 @@ layout: default
 
         .post-list a {
             color: var(--color-link);
-            text-decoration: none;
-            position: relative;
-            display: inline-block;
-            border-bottom: 1px dotted currentColor;
-            transition: color 0.2s ease, border-color 0.2s ease;
+            text-decoration-line: underline;
+            text-decoration-style: dotted;
+            text-decoration-thickness: 1px;
+            text-underline-offset: 2px;
+            transition: color 0.2s ease;
         }
 
         .post-list a:hover {
             color: var(--color-accent);
-            border-bottom-style: solid;
+            text-decoration-style: solid;
         }
 
         .featured-post {

--- a/javascript/theme-toggle.js
+++ b/javascript/theme-toggle.js
@@ -16,7 +16,7 @@ document.addEventListener('DOMContentLoaded', () => {
         applyTheme(theme);
     }
 
-    const saved = localStorage.getItem('theme') || 'dark';
+    const saved = localStorage.getItem('theme') || 'system';
     applyTheme(saved);
 
     if (darkLink) {


### PR DESCRIPTION
## Summary
- make theme default to system preference
- push footer slightly off screen on home page
- adjust blockquote and post title colors for light mode
- use standard underline styling for links

## Testing
- `bundle exec jekyll build` *(fails: Could not locate Gemfile)*
- `jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68588b6c6d54832193ff271442151014