### PR TITLE
Update description and about page text

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,6 +1,6 @@
 # Site settings
 title: Croissanthology
-description: Cleo Scrolls' website about rationality, mundane utility, and our gloriously appollonian expansion into the lightcone
+description: "."
 url: "https://croissanthology.github.io"
 baseurl: "" 
 

--- a/index.html
+++ b/index.html
@@ -143,8 +143,8 @@ layout: default
 
                 <div class="dotted-box">
                     <p><span class="dropcap">I</span>write about rationality, mundane utility, and our gloriously apollonian expansion into the lightcone. Earth is currently under siege: chiefly <a href="https://en.wikipedia.org/wiki/Existential_risk_from_AI">this</a> but also <a href="https://en.wikipedia.org/wiki/Death">this</a> and even <a href="https://en.wikipedia.org/wiki/List_of_cognitive_biases">this</a>. I'm active here, <a href="https://lesswrong.com/users/croissanthology">LessWrong</a>, and <a href="https://x.com/croissanthology">Twitter.</a></p>
-                    <p>You can email me at croissanthology [at] gmail.com. If you think I'd use your money wisely I have a <a href="https://www.patreon.com/cleoscrolls">Patreon</a>. All my writing is <a href="https://croissanthology.com/all">here</a>. I might start with <a href= "https://croissanthology.com/tactics" >this</a> or <a href= "https://croissanthology.com/allowed">this</a>. There is a newsletter; scroll all the way down to find it.</p>
-                    <p>Switch to <a href="#" id="toggle-dark">dark mode</a>, <a href="#" id="toggle-system">system</a>.</p>
+                    <p>You can email me at croissanthology [at] gmail.com. All my writing is <a href="https://croissanthology.com/all">here</a>. I might start with <a href= "https://croissanthology.com/tactics" >this</a> or <a href= "https://croissanthology.com/allowed">this</a>.</p>
+                    <p>Switch to <a href="#" id="toggle-dark">●</a>, <a href="#" id="toggle-system">◐</a>.</p>
                 </div>
             </div>
 


### PR DESCRIPTION
## Summary
- shorten RSS description
- remove Patreon and newsletter references
- show dark/system theme with symbols on about page

## Testing
- `jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68591951674083218eb3e9261b3f89d3