### PR TITLE
Improve mobile layout and theme loading

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -19,6 +19,19 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>{% if page.title %}{{ page.title }} - {% endif %}Croissanthology</title>
     
+    <!-- Apply saved theme before loading CSS to avoid flash -->
+    <script>
+      (function(){
+        var theme = localStorage.getItem('theme') || 'system';
+        if(theme === 'system'){
+          var prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+          document.documentElement.setAttribute('data-theme', prefersDark ? 'dark' : 'light');
+        } else {
+          document.documentElement.setAttribute('data-theme', theme);
+        }
+      })();
+    </script>
+
     <!-- Styles -->
     <link rel="stylesheet" href="{{ '/CSS/styles.css' | relative_url }}">
     <link rel="icon" type="image/svg+xml" href="{{ '/images/green favicon.svg' | relative_url }}">

--- a/index.html
+++ b/index.html
@@ -21,6 +21,7 @@ layout: default
         #custom-substack-embed {
           margin: 20px auto 0;
           max-width: 480px;
+          text-align: center;
         }
 
         #custom-substack-embed input {
@@ -38,6 +39,7 @@ layout: default
           border-radius: 4px !important;
           background-color: var(--color-accent) !important;
           color: var(--color-heading) !important;
+          margin-top: var(--space-s);
         }
         
         :root {
@@ -50,7 +52,7 @@ layout: default
             display: grid;
             grid-template-columns: 1fr 4fr;
             gap: var(--space-l);
-            margin-top: var(--space-l);
+            margin-top: var(--space-m);
         }
 
         .index-left {
@@ -110,8 +112,27 @@ layout: default
                 grid-template-columns: 1fr;
             }
 
+            .index-left {
+                padding-right: 0;
+                border-right: none;
+            }
+
             .index-right {
                 margin-top: var(--space-l);
+                padding-left: 0;
+            }
+
+            .dotted-box {
+                border: none;
+                border-bottom: 1px dotted var(--color-border);
+                padding-left: 0;
+                padding-right: 0;
+            }
+
+            #custom-substack-embed {
+                margin-left: auto;
+                margin-right: auto;
+                max-width: 100%;
             }
 
             .featured-title {


### PR DESCRIPTION
## Summary
- avoid dark-mode flash by applying theme earlier
- refine index layout spacing and make mobile adjustments
- better mobile view: remove dotted box frame, let content span width, and center subscription box

## Testing
- `bundle exec jekyll build` *(fails: Could not locate Gemfile)*

------
https://chatgpt.com/codex/tasks/task_e_685927ec95848321a1c85f00813160aa