### PR TITLE
UI fixes and bolder post titles

### DIFF
--- a/CSS/styles.css
+++ b/CSS/styles.css
@@ -41,7 +41,7 @@ body, h1, h2, h3, h4, h5, h6, p, figure, blockquote, dl, dd {
     --font-body: var(--font-system);
     
     /* Sizing */
-    --content-width: min(1000px, 95vw);
+    --content-width: min(1000px, 100%);
     --line-height: 1.6;
     
     /* Z-index scale */
@@ -217,7 +217,7 @@ a[href*="x.com"]:hover {
 
 .post-title a {
     color: var(--color-accent) !important;
-    font-weight: 300 !important;
+    font-weight: 700 !important;
     border-bottom: none;
 }
 

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -33,7 +33,7 @@ layout: default
     margin-bottom: 0.8em;
     font-size: 2.5rem !important;  /* gwern-scale: prominent but not dominating */
     line-height: 1.2;
-    font-weight: 200;  /* ultra-light weight */
+    font-weight: 700;  /* bold weight */
 }
 
 /* kill the underline on post titles */

--- a/index.html
+++ b/index.html
@@ -19,7 +19,7 @@ layout: default
     <style>
         /* Custom Substack styling */
         #custom-substack-embed {
-          margin: 20px auto 0;
+          margin: 0 auto;
           max-width: 480px;
           text-align: center;
         }
@@ -36,14 +36,14 @@ layout: default
           font-family: 'Poiret One', cursive !important;
           letter-spacing: 2px !important;
           text-transform: uppercase !important;
-          border-radius: 4px !important;
+          border-radius: 0 !important;
           background-color: var(--color-accent) !important;
           color: var(--color-heading) !important;
           margin-top: var(--space-s);
         }
         
         :root {
-        --main-width: min(1000px, 95vw);
+        --main-width: min(1000px, 100%);
             --padding-left: 20px;
         }
         
@@ -133,6 +133,7 @@ layout: default
                 margin-left: auto;
                 margin-right: auto;
                 max-width: 100%;
+                width: 100%;
             }
 
             .featured-title {


### PR DESCRIPTION
## Summary
- emphasize post titles with bold styling
- adjust width variables to avoid mobile overflow
- clean up Substack subscribe embed

## Testing
- `jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68592af4876483219664be59f38607a6