### PR TITLE
Remove RSS and subscribe box, improve mobile margins

### DIFF
--- a/CSS/styles.css
+++ b/CSS/styles.css
@@ -527,7 +527,13 @@ footer {
     }
     
     body {
-        padding: var(--space-s);
+        padding: 0 var(--space-xs);
+    }
+
+    .container,
+    .content-wrapper {
+        padding-left: var(--space-xs);
+        padding-right: var(--space-xs);
     }
     
     .mobile-header {

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -77,9 +77,6 @@
     </div>
     {% endif %}
 
-    <footer>
-        <a href="{{ '/feed.xml' | relative_url }}" target="_blank">RSS Feed</a>
-    </footer>
 
                 
     

--- a/index.html
+++ b/index.html
@@ -17,30 +17,6 @@ layout: default
     <link rel="icon" type="image/svg+xml" href="green favicon.svg">
 
     <style>
-        /* Custom Substack styling */
-        #custom-substack-embed {
-          margin: 0 auto;
-          max-width: 480px;
-          text-align: center;
-        }
-
-        #custom-substack-embed input {
-          font-family: 'Inter', sans-serif !important;
-          border-radius: 0 !important;
-          border: 1px solid #404040 !important;
-          background-color: var(--color-bg) !important;
-          color: var(--color-text) !important;
-        }
-
-        #custom-substack-embed button {
-          font-family: 'Poiret One', cursive !important;
-          letter-spacing: 2px !important;
-          text-transform: uppercase !important;
-          border-radius: 0 !important;
-          background-color: var(--color-accent) !important;
-          color: var(--color-heading) !important;
-          margin-top: var(--space-s);
-        }
         
         :root {
         --main-width: min(1000px, 100%);
@@ -129,12 +105,6 @@ layout: default
                 padding-right: 0;
             }
 
-            #custom-substack-embed {
-                margin-left: auto;
-                margin-right: auto;
-                max-width: 100%;
-                width: 100%;
-            }
 
             .featured-title {
                 font-size: clamp(1.5rem, 8vw, 3rem);
@@ -176,7 +146,6 @@ layout: default
                     <li><a href="{{ post.url }}">{{ post.title }}</a></li>
                 {% endfor %}
                 </ul>
-                <div id="custom-substack-embed"></div>
             </div>
         </div>
 
@@ -187,18 +156,5 @@ layout: default
 </div>
 
 
-<!-- Place substack script before closing body tag -->
-<script>
-window.CustomSubstackWidget = {
-  substackUrl: "croissanthology.substack.com",
-  placeholder: "Type your email...",
-  buttonText: "Subscribe",
-  theme: "custom",
-  colors: {
-    primary: "#4A9C6D"
-  }
-};
-</script>
-<script src="https://substackapi.com/widget.js" async></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- remove the RSS feed footer from the default layout
- delete substack subscribe widget from the homepage
- tighten body padding on mobile for better centering

## Testing
- `jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68592caa2cfc83218a7dacb6b623cb72