### PR TITLE
Update hover styles and text justification

### DIFF
--- a/CSS/styles.css
+++ b/CSS/styles.css
@@ -161,6 +161,8 @@ h1::after, h2::after, h3::after, h4::after, h5::after {
 /* Paragraphs */
 p {
     margin-bottom: var(--space-m);
+    text-align: justify;
+    hyphens: auto;
 }
 
 /* =========================================================
@@ -410,6 +412,11 @@ li {
 
 .title-container:hover .image-replacement {
     opacity: 1;
+}
+
+/* Light mode: make "croiss" white when hovering the title */
+[data-theme="light"] .title-container:hover .title-white {
+    color: #ffffff;
 }
 
 /* Image container */


### PR DESCRIPTION
## Summary
- justify text and enable hyphenation for paragraphs
- ensure "croiss" turns white when the title is hovered in light mode

## Testing
- `bundle exec jekyll build` *(fails: Could not locate Gemfile)*

------
https://chatgpt.com/codex/tasks/task_e_6859412a50e0832188d338d0cbbc8c17