### PR TITLE
Fix mobile spacing and featured post width

### DIFF
--- a/index.html
+++ b/index.html
@@ -110,7 +110,7 @@ layout: default
             }
 
             .index-left {
-                padding-right: 0;
+                padding-right: var(--space-xs);
                 border-right: none;
             }
 
@@ -122,8 +122,13 @@ layout: default
             .dotted-box {
                 border: none;
                 border-bottom: 1px dotted var(--color-border);
-                padding-left: 0;
-                padding-right: 0;
+                padding-left: var(--space-xs);
+                padding-right: var(--space-xs);
+            }
+
+            .featured-post {
+                margin-left: calc(-1 * var(--space-xs));
+                margin-right: calc(-1 * var(--space-s));
             }
 
 


### PR DESCRIPTION
## Summary
- tweak mobile padding around the About section
- add negative margins so the mobile featured post spans the viewport

## Testing
- `jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c616d86d883218e75fc6b9dbf47b4