### PR TITLE
Allow manual selection of front-page posts

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,5 +1,15 @@
 ---
 layout: default
+front_posts:
+  - adequate
+  - tactics
+  - earring
+  - allowed
+  - clone
+  - true
+  - auren
+  - system-prompt
+  - music
 ---
 
 
@@ -172,8 +182,11 @@ layout: default
 
             <div class="index-right">
                 <ul class="post-list">
-                {% for post in site.posts limit:10 %}
+                {% for slug in page.front_posts %}
+                    {% assign post = site.posts | where: "slug", slug | first %}
+                    {% if post %}
                     <li><a href="{{ post.url }}">{{ post.title }}</a></li>
+                    {% endif %}
                 {% endfor %}
                 </ul>
             </div>


### PR DESCRIPTION
## Summary
- Stop automatically listing 10 most recent posts on homepage
- Add configurable `front_posts` list in `index.html` to explicitly control which posts appear

## Testing
- `jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b5dbe9a2d083219b763b52a4fa2278