### PR TITLE
feat: switch default body font to EB Garamond

### DIFF
--- a/CSS/styles.css
+++ b/CSS/styles.css
@@ -38,7 +38,7 @@ body, h1, h2, h3, h4, h5, h6, p, figure, blockquote, dl, dd {
     /* Typography */
     --font-system: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
     --font-display: 'Poiret One', cursive;
-    --font-body: var(--font-system);
+    --font-body: 'EB Garamond', serif;
     
     /* Sizing */
     --content-width: min(1000px, 100%);
@@ -246,9 +246,9 @@ a[href*="x.com"]:hover {
 }
 
 .post-date {
-    color: var(--color-muted);
+    color: #000000;
     font-style: italic;
-    font-size: 0.9rem;
+    font-size: 1.2rem;
 }
 
 .post-content {

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -4,6 +4,7 @@
     <!-- Fonts -->
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500&display=swap" rel="stylesheet">
     <link href="https://fonts.googleapis.com/css2?family=Poiret+One&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=EB+Garamond&display=swap" rel="stylesheet">
     
     <!-- Google Analytics -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-VVQGCQMB02"></script>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -43,11 +43,11 @@ layout: default
 
 .post-date {
     display: block;
-    color: #808080;
+    color: #000000;
     font-style: italic;
     margin-top: 0.5em;
-    font-family: 'Source Serif Pro', serif;
-    font-size: 1.1rem;
+    font-family: var(--font-body);
+    font-size: 1.2rem;
 }
 
 .post-content {

--- a/index.html
+++ b/index.html
@@ -19,6 +19,7 @@ front_posts:
 <head>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500&display=swap" rel="stylesheet">
     <link href="https://fonts.googleapis.com/css2?family=Poiret+One&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=EB+Garamond&display=swap" rel="stylesheet">
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Croissanthology</title>


### PR DESCRIPTION
## Summary
- Load EB Garamond from Google Fonts and make it the site's body font
- Style post date timestamps in black, italic text with a slightly larger size

## Testing
- `npm test` *(fails: Could not read package.json)*
- `jekyll build` *(fails: command not found)*
- `gem install jekyll` *(fails: 403 "Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68b9b4cb7f008321a07bf62a023e0986