### PR TITLE
Add boxed table of contents and enlarge post text

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -52,7 +52,7 @@ layout: default
 
 .post-content {
     margin-top: 4em;
-    font-size: 1.35rem;  /* bigger body text */
+    font-size: 1.25rem;  /* body text */
     line-height: 1.8;
 }
 
@@ -190,7 +190,7 @@ label.margin-toggle {
     }
     
     .post-content {
-        font-size: 1.2rem;
+        font-size: 1.1rem;
     }
     
     .post-header {

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -52,7 +52,7 @@ layout: default
 
 .post-content {
     margin-top: 4em;
-    font-size: 1.25rem;  /* bigger body text */
+    font-size: 1.35rem;  /* bigger body text */
     line-height: 1.8;
 }
 
@@ -118,6 +118,35 @@ layout: default
 .sidenote-number:after {
     display: none;
 }
+
+/* table of contents */
+.toc-and-intro {
+    display: flex;
+    gap: var(--space-l);
+    margin-bottom: var(--space-xl);
+}
+
+.post-toc {
+    width: 50%;
+    border: 1px solid var(--color-border);
+    padding: var(--space-m);
+    font-family: var(--font-system);
+    font-weight: 700;
+}
+
+.post-toc ol {
+    list-style: none;
+    margin: 0;
+    padding-left: 0;
+}
+
+.post-toc li {
+    margin-bottom: var(--space-xs);
+}
+
+.post-intro {
+    width: 50%;
+}
    
 input.margin-toggle,
 label.margin-toggle {
@@ -161,7 +190,7 @@ label.margin-toggle {
     }
     
     .post-content {
-        font-size: 1.1rem;
+        font-size: 1.2rem;
     }
     
     .post-header {
@@ -176,5 +205,18 @@ label.margin-toggle {
         background: rgba(255, 255, 255, 0.05);
         border-left: 2px solid #4A9C6D;
     }
+
+    .toc-and-intro {
+        display: block;
+    }
+
+    .post-toc {
+        display: none;
+    }
+
+    .post-intro {
+        width: 100%;
+    }
 }
 </style>
+<script src="{{ '/javascript/toc.js' | relative_url }}" defer></script>

--- a/javascript/toc.js
+++ b/javascript/toc.js
@@ -1,0 +1,57 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const content = document.querySelector('.post-content');
+  if (!content) return;
+
+  const headings = content.querySelectorAll('h2, h3, h4, h5, h6');
+  if (headings.length === 0) return;
+
+  const firstHeading = headings[0];
+  const introNodes = [];
+  let node = content.firstChild;
+  while (node && node !== firstHeading) {
+    const next = node.nextSibling;
+    introNodes.push(node);
+    node = next;
+  }
+
+  const introDiv = document.createElement('div');
+  introDiv.className = 'post-intro';
+  introNodes.forEach(n => introDiv.appendChild(n));
+
+  const tocList = document.createElement('ol');
+  const counters = [];
+
+  headings.forEach(h => {
+    const level = parseInt(h.tagName.substring(1));
+    if (level < 2) return;
+    const depth = level - 2;
+
+    counters[depth] = (counters[depth] || 0) + 1;
+    counters.length = depth + 1;
+    const number = counters.join('.');
+
+    if (!h.id) {
+      h.id = `toc-${number.replace(/\./g, '-')}`;
+    }
+
+    const li = document.createElement('li');
+    li.style.marginLeft = depth * 16 + 'px';
+
+    const a = document.createElement('a');
+    a.href = '#' + h.id;
+    a.textContent = `${number} ${h.textContent}`;
+    li.appendChild(a);
+    tocList.appendChild(li);
+  });
+
+  const tocNav = document.createElement('nav');
+  tocNav.className = 'post-toc';
+  tocNav.appendChild(tocList);
+
+  const wrapper = document.createElement('div');
+  wrapper.className = 'toc-and-intro';
+  wrapper.appendChild(tocNav);
+  wrapper.appendChild(introDiv);
+
+  content.insertBefore(wrapper, firstHeading);
+});


### PR DESCRIPTION
## Summary
- expand post body font to 1.35rem for easier reading
- introduce responsive boxed table of contents beside the intro when headings exist
- fix table of contents not rendering by loading `toc.js` via Jekyll's `relative_url`

## Testing
- `gem install jekyll bundler` *(fails: 403 Forbidden)*
- `jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b9c636e78483218e151c7b8587a9ad