### PR TITLE
Refine post typography and interactive headings

### DIFF
--- a/CSS/styles.css
+++ b/CSS/styles.css
@@ -21,6 +21,7 @@ body, h1, h2, h3, h4, h5, h6, p, figure, blockquote, dl, dd {
     --color-bg: #1a1a1a;
     --color-text: #e0e0e0;
     --color-heading: #ffffff;
+    --color-heading-hover: #b3b3b3;
     --color-accent: #4A9C6D;
     --color-link: #e0e0e0;
     --color-muted: #888888;
@@ -56,6 +57,7 @@ body, h1, h2, h3, h4, h5, h6, p, figure, blockquote, dl, dd {
     --color-bg: #f5f5f5;
     --color-text: #333333;
     --color-heading: #000000;
+    --color-heading-hover: #555555;
     /* Lighter accent for light mode */
     --color-accent: #6fb88a;
     --color-link: #333333;
@@ -131,13 +133,19 @@ body {
 /* Headings */
 h1, h2, h3, h4, h5, h6 {
     font-family: var(--font-display);
-    font-weight: 200; /* Ultra light to mimic Poiret One's thin strokes */
+    font-weight: 700;
     color: var(--color-heading);
     text-transform: uppercase;
     letter-spacing: 0.15em; /* Slightly more spacing for that airy feel */
     line-height: 1.2;
     margin-top: var(--space-xl);
     margin-bottom: var(--space-m);
+    cursor: pointer;
+    transition: color 0.2s ease;
+}
+
+h1:hover, h2:hover, h3:hover, h4:hover, h5:hover, h6:hover {
+    color: var(--color-heading-hover);
 }
 
 /* Responsive heading sizes using clamp() */
@@ -154,7 +162,7 @@ h1::after, h2::after, h3::after, h4::after, h5::after {
     display: block;
     width: 100%;
     height: 1px;
-    background-color: var(--color-heading);
+    background-color: currentColor;
     margin-top: var(--space-xs);
 }
 

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -85,5 +85,6 @@
     <script src="{{ '/javascript/javaventuraayayay.js' | relative_url }}"></script>
     <script src="{{ '/javascript/side-title.js' | relative_url }}"></script>
     <script src="{{ '/javascript/theme-toggle.js' | relative_url }}"></script>
+    <script src="{{ '/javascript/heading-links.js' | relative_url }}"></script>
 </body>
 </html>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -52,8 +52,8 @@ layout: default
 
 .post-content {
     margin-top: 4em;
-    font-size: 1.35rem;  /* bigger body text */
-    line-height: 1.8;
+    font-size: 1.25rem;  /* slightly smaller body text */
+    line-height: 1.5;  /* tighter line spacing */
 }
 
 /* kill the dropcap */
@@ -190,7 +190,7 @@ label.margin-toggle {
     }
     
     .post-content {
-        font-size: 1.2rem;
+        font-size: 1.1rem;
     }
     
     .post-header {

--- a/javascript/heading-links.js
+++ b/javascript/heading-links.js
@@ -1,0 +1,17 @@
+// Adds link-copying functionality to post headings
+// When a heading is clicked, its URL is copied to the clipboard
+
+document.addEventListener('DOMContentLoaded', () => {
+  const headings = document.querySelectorAll('.post-content h1, .post-content h2, .post-content h3, .post-content h4, .post-content h5, .post-content h6');
+  if (!headings.length) return;
+
+  headings.forEach(h => {
+    if (!h.id) {
+      h.id = h.textContent.trim().toLowerCase().replace(/[^a-z0-9\s-]/g, '').replace(/\s+/g, '-');
+    }
+    h.addEventListener('click', () => {
+      const url = `${window.location.origin}${window.location.pathname}#${h.id}`;
+      navigator.clipboard.writeText(url).catch(err => console.error('Copy failed', err));
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Reduce default post font size and line height for a denser reading experience
- Make headings bold with theme-aware hover styling
- Enable heading clicks to copy direct links to clipboard

## Testing
- `npm test` *(fails: Could not read package.json)*
- `jekyll build` *(fails: command not found)*
- `bundle exec jekyll build` *(fails: Could not locate Gemfile or .bundle/ directory)*

------
https://chatgpt.com/codex/tasks/task_e_68bac7f401ac8321baf8a267688bd9e6