### PR TITLE
Add randomized 404 page and update post date styling

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,0 +1,49 @@
+---
+layout: default
+permalink: /404.html
+---
+<div id="random-404"></div>
+<script>
+const options = [
+  `<div class="four-oh-four-option">
+      <h1>404 Not Found</h1>
+      <p class="quote">
+        <span>“Zounds, this page was undoubtedly”</span>
+        <span class="offset">
+          <a href="https://gwern.net/suzanne-delage">suzanne-delaged</a> by some stray vampire. Tough luck.”
+        </span>
+      </p>
+      <img src="/images/vampire.png" alt="Vampire">
+   </div>`
+];
+const choice = options[Math.floor(Math.random() * options.length)];
+document.getElementById('random-404').innerHTML = choice;
+</script>
+<style>
+#random-404 {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  min-height: 80vh;
+}
+#random-404 img {
+  max-width: 400px;
+  height: auto;
+  border: none;
+  margin-top: 1rem;
+}
+#random-404 .quote {
+  margin-top: 1rem;
+  font-family: var(--font-body);
+  font-style: normal;
+  font-size: 1.5rem;
+}
+#random-404 .quote span {
+  display: block;
+}
+#random-404 .quote .offset {
+  margin-left: 2rem;
+}
+</style>

--- a/CSS/styles.css
+++ b/CSS/styles.css
@@ -246,8 +246,8 @@ a[href*="x.com"]:hover {
 }
 
 .post-date {
-    color: #000000;
-    font-style: italic;
+    color: var(--color-heading);
+    font-style: normal;
     font-size: 1.2rem;
 }
 

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -43,8 +43,8 @@ layout: default
 
 .post-date {
     display: block;
-    color: #000000;
-    font-style: italic;
+    color: var(--color-heading);
+    font-style: normal;
     margin-top: 0.5em;
     font-family: var(--font-body);
     font-size: 1.2rem;


### PR DESCRIPTION
## Summary
- Introduce a custom 404 page that randomly selects a message and displays a single transparent `vampire.png` image
- Style the quote above the image in two offset lines for a more dramatic presentation
- Ensure post dates use heading color, appear white in dark mode, and are no longer italicized

## Testing
- `jekyll build` *(fails: command not found)*
- `gem install jekyll bundler` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68bac75aa2548321bf9e09700acd4cbb