### PR TITLE
Refine post layout and table of contents

### DIFF
--- a/CSS/styles.css
+++ b/CSS/styles.css
@@ -54,7 +54,7 @@ body, h1, h2, h3, h4, h5, h6, p, figure, blockquote, dl, dd {
 
 /* Light theme */
 :root[data-theme="light"] {
-    --color-bg: #f5f5f5;
+    --color-bg: #ffffff;
     --color-text: #333333;
     --color-heading: #000000;
     --color-heading-hover: #555555;

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -14,7 +14,7 @@ layout: default
 </article>
 <style>
 .post-header {
-    margin-top: 10em;  /* more breathing room */
+    margin-top: 6em;  /* more breathing room */
     text-align: center;
     margin-bottom: 5em;
 }
@@ -127,7 +127,7 @@ layout: default
 }
 
 .post-toc {
-    width: 50%;
+    width: 33%;
     border: 1px solid var(--color-border);
     padding: var(--space-m);
     font-family: var(--font-system);
@@ -144,8 +144,18 @@ layout: default
     margin-bottom: var(--space-xs);
 }
 
+.post-toc a {
+    text-decoration: none;
+    color: inherit;
+}
+
+.post-toc .toc-number {
+    color: var(--color-muted);
+    margin-right: 0.5em;
+}
+
 .post-intro {
-    width: 50%;
+    width: 67%;
 }
    
 input.margin-toggle,

--- a/javascript/toc.js
+++ b/javascript/toc.js
@@ -39,7 +39,11 @@ document.addEventListener('DOMContentLoaded', () => {
 
     const a = document.createElement('a');
     a.href = '#' + h.id;
-    a.textContent = `${number} ${h.textContent}`;
+    const numSpan = document.createElement('span');
+    numSpan.className = 'toc-number';
+    numSpan.textContent = number;
+    a.appendChild(numSpan);
+    a.append(' ' + h.textContent);
     li.appendChild(a);
     tocList.appendChild(li);
   });


### PR DESCRIPTION
## Summary
- set light-mode background to pure white
- shrink table of contents to one-third width, style grey numbers without underlines, and expand intro section
- reduce top margin above post titles for a tighter layout

## Testing
- `jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bc64c1208c83218d21a404dded251b