### PR TITLE
Inline critical styles and lazy-load images

### DIFF
--- a/CSS/styles.css
+++ b/CSS/styles.css
@@ -27,6 +27,7 @@ body, h1, h2, h3, h4, h5, h6, p, figure, blockquote, dl, dd {
     --color-muted: #888888;
     --color-border: #404040;
     --color-blockquote: #c0c0c0;
+    --color-image-border: #ffffff;
     
     /* Spacing scale (8px base) */
     --space-xs: 0.5rem;
@@ -64,6 +65,7 @@ body, h1, h2, h3, h4, h5, h6, p, figure, blockquote, dl, dd {
     --color-muted: #666666;
     --color-border: #cccccc;
     --color-blockquote: #555555;
+    --color-image-border: #000000;
 }
 
 /* =========================================================
@@ -279,6 +281,15 @@ a[href*="gwern.net"]:hover {
 
 .post-content {
     margin-top: var(--space-xl);
+}
+
+.post-content p > img {
+    display: block;
+    margin: var(--space-l) auto;
+    max-width: 90%;
+    height: auto;
+    border: 1px solid var(--color-image-border);
+    box-sizing: border-box;
 }
 
 /* First paragraph drop cap */

--- a/_config.yml
+++ b/_config.yml
@@ -23,6 +23,7 @@ collections:
 # Plugins
 plugins:
   - jekyll-feed
+  - jekyll-minifier
 
 # Feed settings
 feed:

--- a/_includes/critical.css
+++ b/_includes/critical.css
@@ -1,0 +1,139 @@
+/* Critical CSS: base typography, layout, and header */
+*, *::before, *::after {
+    box-sizing: border-box;
+}
+
+body, h1, h2, h3, h4, h5, h6, p {
+    margin: 0;
+}
+
+:root {
+    --color-bg: #1a1a1a;
+    --color-text: #e0e0e0;
+    --color-heading: #ffffff;
+    --color-heading-hover: #b3b3b3;
+    --color-accent: #4A9C6D;
+    --color-link: #e0e0e0;
+    --color-muted: #888888;
+    --color-border: #404040;
+    --font-display: 'Poiret One', cursive;
+    --font-body: 'EB Garamond', serif;
+    --content-width: min(1000px, 100%);
+    --space-xs: 0.5rem;
+    --space-s: 1rem;
+    --space-m: 1.5rem;
+    --space-xl: 3rem;
+    --line-height: 1.6;
+    --z-overlay: 50;
+}
+
+:root[data-theme="light"] {
+    --color-bg: #ffffff;
+    --color-text: #333333;
+    --color-heading: #000000;
+    --color-heading-hover: #555555;
+    --color-accent: #6fb88a;
+    --color-link: #333333;
+    --color-muted: #666666;
+    --color-border: #cccccc;
+}
+
+body {
+    font-family: var(--font-body);
+    font-size: 16px;
+    line-height: var(--line-height);
+    color: var(--color-text);
+    background-color: var(--color-bg);
+    min-height: 100vh;
+    padding: var(--space-m);
+    overflow-x: hidden;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+    text-rendering: optimizeLegibility;
+}
+
+.container,
+.content-wrapper,
+section {
+    width: var(--content-width);
+    max-width: 100%;
+    margin: 0 auto;
+    padding: 0 var(--space-m);
+}
+
+h1, h2, h3, h4, h5, h6 {
+    font-family: var(--font-display);
+    font-weight: 700;
+    color: var(--color-heading);
+    text-transform: uppercase;
+    letter-spacing: 0.15em;
+    line-height: 1.2;
+    margin-top: var(--space-xl);
+    margin-bottom: var(--space-m);
+}
+
+p {
+    margin-bottom: var(--space-m);
+}
+
+.mobile-header {
+    display: none;
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    background-color: var(--color-bg);
+    border-bottom: 1px solid var(--color-border);
+    z-index: var(--z-overlay);
+    transform: translateY(-100%);
+    transition: transform 0.3s ease;
+}
+
+.mobile-header.visible {
+    transform: translateY(0);
+}
+
+.mobile-header-title {
+    font-family: var(--font-display);
+    font-weight: 200;
+    font-size: 0.875rem;
+    text-align: center;
+    padding: var(--space-s);
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+}
+
+.progress-bar {
+    height: 2px;
+    background-color: var(--color-accent);
+    width: 0;
+    transition: width 0.2s ease;
+}
+
+@media (min-width: 768px) {
+    .mobile-header {
+        display: none;
+    }
+}
+
+@media (max-width: 768px) {
+    :root {
+        --content-width: 100%;
+    }
+
+    body {
+        padding-left: var(--space-xs);
+        padding-right: var(--space-s);
+    }
+
+    .container,
+    .content-wrapper,
+    section {
+        padding-left: var(--space-xs);
+        padding-right: var(--space-s);
+    }
+
+    .mobile-header {
+        display: block;
+    }
+}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -5,15 +5,10 @@
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500&display=swap" rel="stylesheet">
     <link href="https://fonts.googleapis.com/css2?family=Poiret+One&display=swap" rel="stylesheet">
     <link href="https://fonts.googleapis.com/css2?family=EB+Garamond&display=swap" rel="stylesheet">
-    
-    <!-- Google Analytics -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-VVQGCQMB02"></script>
-    <script>
-      window.dataLayer = window.dataLayer || [];
-      function gtag(){dataLayer.push(arguments);}
-      gtag('js', new Date());
-      gtag('config', 'G-VVQGCQMB02');
-    </script>
+
+    <!-- Resource hints for external assets -->
+    <link rel="dns-prefetch" href="//i.imgur.com">
+    <link rel="preconnect" href="https://i.imgur.com" crossorigin>
     
     <!-- Meta -->
     <meta charset="UTF-8">
@@ -87,15 +82,11 @@
     </script>
 
     <!-- Styles -->
-    <link rel="stylesheet" href="{{ '/CSS/styles.css' | relative_url }}">
+    <style>{% include critical.css %}</style>
+    <link rel="preload" href="{{ '/CSS/styles.css' | relative_url }}" as="style">
+    <link rel="stylesheet" href="{{ '/CSS/styles.css' | relative_url }}" media="print" onload="this.media='all'">
+    <noscript><link rel="stylesheet" href="{{ '/CSS/styles.css' | relative_url }}"></noscript>
     <link rel="icon" type="image/svg+xml" href="{{ '/images/green favicon.svg' | relative_url }}">
-    <style>
-        @media (min-width: 768px) {
-            .mobile-header {
-                display: none;
-            }
-        }
-    </style>
 </head>
 <body class="bg-[#1a1a1a] text-[#e0e0e0] {% if page.url == "/" %}index{% endif %}">
     {% if page.layout == 'post' %}
@@ -138,6 +129,43 @@
                 
     
     <!-- Scripts -->
+    <script>
+    document.addEventListener('DOMContentLoaded', function() {
+      document.querySelectorAll('img').forEach(function(img) {
+        if (!img.hasAttribute('loading')) {
+          img.loading = 'lazy';
+        }
+        if (!img.hasAttribute('decoding')) {
+          img.decoding = 'async';
+        }
+      });
+
+      document.querySelectorAll('img[src*="imgur"]').forEach(function(img) {
+        if (img.hasAttribute('srcset')) {
+          return;
+        }
+
+        var src = img.getAttribute('src');
+        if (!src || src.indexOf('.jpg') === -1 && src.indexOf('.JPG') === -1 && src.indexOf('.jpeg') === -1 && src.indexOf('.JPEG') === -1) {
+          return;
+        }
+
+        var urlParts = src.split('?');
+        var basePath = urlParts[0];
+        var query = urlParts.length > 1 ? '?' + urlParts.slice(1).join('?') : '';
+
+        var halfSizePath = basePath.replace(/\.jpe?g$/i, function(match) {
+          return 'h' + match;
+        });
+
+        if (halfSizePath === basePath) {
+          return;
+        }
+
+        img.srcset = src + ' 1x, ' + halfSizePath + query + ' 0.5x';
+      });
+    });
+    </script>
     <script src="{{ '/javascript/javaventuraayayay.js' | relative_url }}"></script>
     <script src="{{ '/javascript/side-title.js' | relative_url }}"></script>
     <script src="{{ '/javascript/theme-toggle.js' | relative_url }}"></script>


### PR DESCRIPTION
## Summary
- remove the embedded Google Analytics loader and add resource hints for external assets
- inline a new critical CSS include, defer the main stylesheet, and deliver lazy-loaded images with imgur srcset support
- enable the jekyll-minifier plugin to keep generated assets compressed

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d86735e7388321be2924c9fa46b848