### PR TITLE
Add jekyll redirect plugin configuration

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,9 @@
+source "https://rubygems.org"
+
+gem "jekyll", group: :jekyll_plugins
+
+group :jekyll_plugins do
+  gem "jekyll-feed"
+  gem "jekyll-minifier"
+  gem "jekyll-redirect-from"
+end

--- a/_config.yml
+++ b/_config.yml
@@ -24,6 +24,7 @@ collections:
 plugins:
   - jekyll-feed
   - jekyll-minifier
+  - jekyll-redirect-from
 
 # Feed settings
 feed:


### PR DESCRIPTION
## Summary
- enable the jekyll-redirect-from plugin in the site configuration so redirects can be generated
- add a Gemfile declaring the redirect plugin (and existing plugins) for local Bundler installs

## Testing
- `bundle install` *(fails: 403 Forbidden fetching gems from rubygems.org in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d87a87cfa48321a167df9141fcbe58