### PR TITLE
Add Open Graph and Twitter meta tags to default layout

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -15,6 +15,12 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="author" content="Croissanthology">
     <meta property="article:author" content="Croissanthology">
+    <meta property="og:title" content="{% if page.title %}{{ page.title | escape }}{% else %}{{ site.title | escape }}{% endif %}">
+    <meta property="og:description" content="{% if page.excerpt %}{{ page.excerpt | strip_html | strip_newlines | truncate: 160 }}{% elsif page.description %}{{ page.description }}{% else %}{{ site.description }}{% endif %}">
+    <meta property="og:url" content="{{ page.url | absolute_url }}">
+    <meta property="og:site_name" content="{{ site.title }}">
+    <meta property="og:image" content="{% if page.image %}{{ page.image | absolute_url }}{% else %}{{ '/images/green favicon.svg' | absolute_url }}{% endif %}">
+    <meta name="twitter:card" content="summary_large_image">
     <script type="application/ld+json">
     {
       "@context": "https://schema.org",


### PR DESCRIPTION
## Summary
- add Open Graph metadata for title, description, URL, site name, and preview image
- default the social image to the site's favicon when a page-specific image is not provided
- include a Twitter summary card declaration for improved sharing previews

## Testing
- No tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d945bd4a348321994112462882037f