### PR TITLE
Add Twitter metadata tags to default layout

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -20,6 +20,9 @@
     <meta property="og:url" content="{{ page.url | absolute_url }}">
     <meta property="og:site_name" content="{{ site.title }}">
     <meta property="og:image" content="{% if page.image %}{{ page.image | absolute_url }}{% else %}{{ '/images/vampirehead.png' | absolute_url }}{% endif %}">
+    <meta name="twitter:title" content="{% if page.title %}{{ page.title | escape }}{% else %}{{ site.title | escape }}{% endif %}">
+    <meta name="twitter:description" content="{% if page.excerpt %}{{ page.excerpt | strip_html | strip_newlines | truncate: 160 }}{% elsif page.description %}{{ page.description }}{% else %}{{ site.description }}{% endif %}">
+    <meta name="twitter:image" content="{% if page.image %}{{ page.image | absolute_url }}{% else %}{{ '/images/vampirehead.png' | absolute_url }}{% endif %}">
     <meta name="twitter:card" content="summary_large_image">
     <script type="application/ld+json">
     {


### PR DESCRIPTION
## Summary
- add Twitter title, description, and image metadata to the default layout using the same logic as the OpenGraph tags

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d9515b7fac8321ae3b6113ec6691aa