### PR TITLE
Adjust image borders for theme contrast

### DIFF
--- a/CSS/styles.css
+++ b/CSS/styles.css
@@ -483,7 +483,7 @@ li {
 .image-container {
     margin: var(--space-xl) auto;
     max-width: 100%;
-    border: 1px solid var(--color-border);
+    border: 1px solid var(--color-image-border);
     padding: var(--space-s);
 }
 


### PR DESCRIPTION
## Summary
- use the existing `--color-image-border` token for `.image-container` so the frame swaps between white in dark mode and black in light mode

## Testing
- no automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68da57e6b7d48321a5b10e99278c16a6