### PR TITLE
Align mobile gutters between critical and main CSS

### DIFF
--- a/CSS/styles.css
+++ b/CSS/styles.css
@@ -594,14 +594,12 @@ footer {
     }
     
     body {
-        padding-left: var(--space-xs);
-        padding-right: var(--space-s);
+        padding-inline: var(--space-xs);
     }
 
     .container,
     .content-wrapper {
-        padding-left: var(--space-xs);
-        padding-right: var(--space-s);
+        padding-inline: var(--space-xs);
     }
     
     .mobile-header {

--- a/_includes/critical.css
+++ b/_includes/critical.css
@@ -122,15 +122,13 @@ p {
     }
 
     body {
-        padding-left: var(--space-xs);
-        padding-right: var(--space-s);
+        padding-inline: var(--space-xs);
     }
 
     .container,
     .content-wrapper,
     section {
-        padding-left: var(--space-xs);
-        padding-right: var(--space-s);
+        padding-inline: var(--space-xs);
     }
 
     .mobile-header {


### PR DESCRIPTION
## Summary
- apply a consistent padding-inline gutter for body and layout wrappers in the mobile breakpoint
- mirror the same gutter update in the critical CSS to keep initial render aligned with deferred styles

## Testing
- Manual verification in a 390px-wide viewport

------
https://chatgpt.com/codex/tasks/task_e_68da6b6799388321a8c0befb6600e770