### PR TITLE
Fix index page structure for consistent mobile layout

### DIFF
--- a/CSS/styles.css
+++ b/CSS/styles.css
@@ -509,6 +509,120 @@ li {
     border: 1px dotted var(--color-muted);
 }
 
+/* =========================================================
+   Index Page Layout
+   ========================================================= */
+
+.index-main-layout {
+    display: grid;
+    grid-template-columns: 1fr 4fr;
+    gap: var(--space-l);
+    margin-top: var(--space-m);
+}
+
+.index-left {
+    padding-right: var(--space-l);
+    border-right: 1px dotted var(--color-border);
+}
+
+.index-right {
+    padding-left: var(--space-l);
+}
+
+.post-list {
+    list-style: none;
+    padding: 0;
+}
+
+.post-list li {
+    margin-bottom: var(--space-xs);
+}
+
+.post-list a {
+    color: var(--color-link);
+    text-decoration-line: underline;
+    text-decoration-style: dotted;
+    text-decoration-thickness: 1px;
+    text-underline-offset: 2px;
+    transition: color 0.2s ease;
+}
+
+.post-list a:hover {
+    color: var(--color-accent);
+    text-decoration-style: solid;
+}
+
+.featured-post {
+    margin-top: var(--space-2xl);
+    text-align: center;
+    position: relative;
+    overflow: hidden;
+}
+
+.featured-image {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    opacity: 0.9;
+    z-index: 0;
+}
+
+.featured-image img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    object-position: center;
+}
+
+.featured-title {
+    font-size: clamp(2rem, 6vw, 4rem);
+    letter-spacing: 0.15em;
+    text-transform: uppercase;
+    position: relative;
+    z-index: 1;
+}
+
+.featured-title a {
+    color: #ffffff;
+    text-decoration: none;
+}
+
+.featured-title a:hover {
+    opacity: 0.8;
+}
+
+@media (max-width: 768px) {
+    .index-main-layout {
+        grid-template-columns: 1fr;
+    }
+
+    .index-left {
+        padding-right: var(--space-xs);
+        border-right: none;
+    }
+
+    .index-right {
+        margin-top: var(--space-l);
+        padding-left: 0;
+    }
+
+    .dotted-box {
+        border: none;
+        border-bottom: 1px dotted var(--color-border);
+        padding-inline: var(--space-xs);
+    }
+
+    .featured-post {
+        margin-left: calc(-1 * var(--space-xs));
+        margin-right: calc(-1 * var(--space-xs));
+    }
+
+    .featured-title {
+        font-size: clamp(1.5rem, 8vw, 3rem);
+    }
+}
+
 /* Essay lists */
 .essay-lists-container {
     display: grid;

--- a/index.html
+++ b/index.html
@@ -12,198 +12,43 @@ front_posts:
   - adequate
 ---
 
-
-<!DOCTYPE html>
-
-<html lang="en">
-<head>
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500&display=swap" rel="stylesheet">
-    <link href="https://fonts.googleapis.com/css2?family=Poiret+One&display=swap" rel="stylesheet">
-    <link href="https://fonts.googleapis.com/css2?family=EB+Garamond&display=swap" rel="stylesheet">
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Croissanthology</title>
-    <link rel="stylesheet" href="CSS/styles.css">
-    <script src="javascript/javaventuraayayay.js" defer></script>
-    <link rel="icon" type="image/svg+xml" href="green favicon.svg">
-
-    <style>
-        
-        :root {
-        --main-width: min(1000px, 100%);
-            --padding-left: 20px;
-        }
-        
-        /* Index layout */
-        .index-main-layout {
-            display: grid;
-            grid-template-columns: 1fr 4fr;
-            gap: var(--space-l);
-            margin-top: var(--space-m);
-        }
-
-        .index-left {
-            padding-right: var(--space-l);
-            border-right: 1px dotted var(--color-border);
-        }
-
-        .index-right {
-            padding-left: var(--space-l);
-        }
-
-        .post-list {
-            list-style: none;
-            padding: 0;
-        }
-
-        .post-list li {
-            margin-bottom: var(--space-xs);
-        }
-
-        .post-list a {
-            color: var(--color-link);
-            text-decoration-line: underline;
-            text-decoration-style: dotted;
-            text-decoration-thickness: 1px;
-            text-underline-offset: 2px;
-            transition: color 0.2s ease;
-        }
-
-        .post-list a:hover {
-            color: var(--color-accent);
-            text-decoration-style: solid;
-        }
-
-        .featured-post {
-            margin-top: var(--space-2xl);
-            text-align: center;
-            position: relative;
-            overflow: hidden;
-        }
-
-        .featured-image {
-            position: absolute;
-            top: 0;
-            left: 0;
-            width: 100%;
-            height: 100%;
-            opacity: 0.9;
-            z-index: 0;
-        }
-
-        .featured-image img {
-            width: 100%;
-            height: 100%;
-            object-fit: cover;
-            object-position: center;
-        }
-
-        .featured-title {
-            font-size: clamp(2rem, 6vw, 4rem);
-            letter-spacing: 0.15em;
-            text-transform: uppercase;
-            position: relative;
-            z-index: 1;
-        }
-
-        .featured-title a {
-            color: #ffffff;
-            text-decoration: none;
-        }
-
-        .featured-title a:hover {
-            opacity: 0.8;
-        }
-
-        @media (max-width: 768px) {
-            .index-main-layout {
-                grid-template-columns: 1fr;
-            }
-
-            .content-wrapper {
-    padding: 0 var(--space-xs);
-}
-
-            .index-left {
-                padding-right: var(--space-xs);
-                border-right: none;
-            }
-
-            .index-right {
-                margin-top: var(--space-l);
-                padding-left: 0;
-            }
-
-            .dotted-box {
-                border: none;
-                border-bottom: 1px dotted var(--color-border);
-                padding-left: var(--space-xs);
-                padding-right: var(--space-xs);
-            }
-
-            .featured-post {
-                margin-left: calc(-1 * var(--space-xs));
-                margin-right: calc(-1 * var(--space-s));
-            }
-
-
-            .featured-title {
-                font-size: clamp(1.5rem, 8vw, 3rem);
-            }
-        }
-    </style>
-</head>  
-
-<body class="index">
-    <div class="mobile-header">
-        <h6 class="mobile-header-title">Croissanthology</h6>
-        <div class="progress-bar"></div>
-    </div> 
-
-
-    <div class="content-wrapper">
-        <div class="index-main-layout">
-            <div class="index-left">
-                <div class="title-container">
-                    <h1 class="title">
-                        <span class="title-white">Croiss</span><span class="title-green">anthology</span>
-                    </h1>
-                    <div class="shine-effect"></div>
-                    <div class="image-replacement">
-                        <img src="images/croissanthology-image-1.webp" alt="Oh look a tiny easter egg!">
-                    </div>
-                </div>
-
-                <div class="dotted-box">
-                    <p><span class="dropcap">I</span>write about rationality, mundane utility, and our gloriously apollonian expansion into the lightcone. Earth is currently under siege: chiefly <a href="https://en.wikipedia.org/wiki/Existential_risk_from_AI">this</a> but also <a href="https://en.wikipedia.org/wiki/Death">this</a> and even <a href="https://en.wikipedia.org/wiki/List_of_cognitive_biases">this</a>. I'm active here, <a href="https://lesswrong.com/users/croissanthology">LessWrong</a>, and <a href="https://x.com/croissanthology">Twitter.</a> Inspirations include, but are not limited to, <a href="https://gwern.net">the</a> <a href="https://gleech.org">three</a> <a href="https://guzey.com">Gs</a>.</p>
-                    <p>You can email me at croissanthology [at] gmail.com. All my writing is <a href="https://croissanthology.com/all">here</a>. I might start with <a href= "https://croissanthology.com/tactics" >this</a> or <a href= "https://croissanthology.com/allowed">this</a>.</p>
-                    <p>Switch to <a href="#" id="toggle-dark">●</a>, <a href="#" id="toggle-system">◐</a>.</p>
-                </div>
-            </div>
-
-            <div class="index-right">
-                <ul class="post-list">
-                {% for slug in page.front_posts %}
-                    {% assign post = site.posts | where: "slug", slug | first %}
-                    {% if post %}
-                    <li><a href="{{ post.url }}">{{ post.title }}</a></li>
-                    {% endif %}
-                {% endfor %}
-                </ul>
+<div class="index-main-layout">
+    <div class="index-left">
+        <div class="title-container">
+            <h1 class="title">
+                <span class="title-white">Croiss</span><span class="title-green">anthology</span>
+            </h1>
+            <div class="shine-effect"></div>
+            <div class="image-replacement">
+                <img src="images/croissanthology-image-1.webp" alt="Oh look a tiny easter egg!">
             </div>
         </div>
 
-        {% assign starred_posts = site.posts | where: "starred", true %}
-        {% for post in starred_posts %}
-        <div class="featured-post">
-            <div class="featured-image">
-                <img src="images/skyline.png" alt="">
-            </div>
-            <h2 class="featured-title"><a href="{{ post.url }}">{{ post.title }}</a></h2>
+        <div class="dotted-box">
+            <p><span class="dropcap">I</span>write about rationality, mundane utility, and our gloriously apollonian expansion into the lightcone. Earth is currently under siege: chiefly <a href="https://en.wikipedia.org/wiki/Existential_risk_from_AI">this</a> but also <a href="https://en.wikipedia.org/wiki/Death">this</a> and even <a href="https://en.wikipedia.org/wiki/List_of_cognitive_biases">this</a>. I'm active here, <a href="https://lesswrong.com/users/croissanthology">LessWrong</a>, and <a href="https://x.com/croissanthology">Twitter.</a> Inspirations include, but are not limited to, <a href="https://gwern.net">the</a> <a href="https://gleech.org">three</a> <a href="https://guzey.com">Gs</a>.</p>
+            <p>You can email me at croissanthology [at] gmail.com. All my writing is <a href="https://croissanthology.com/all">here</a>. I might start with <a href="https://croissanthology.com/tactics">this</a> or <a href="https://croissanthology.com/allowed">this</a>.</p>
+            <p>Switch to <a href="#" id="toggle-dark">●</a>, <a href="#" id="toggle-system">◐</a>.</p>
         </div>
+    </div>
+
+    <div class="index-right">
+        <ul class="post-list">
+        {% for slug in page.front_posts %}
+            {% assign post = site.posts | where: "slug", slug | first %}
+            {% if post %}
+            <li><a href="{{ post.url }}">{{ post.title }}</a></li>
+            {% endif %}
         {% endfor %}
+        </ul>
+    </div>
 </div>
 
-
-</body>
-</html>
+{% assign starred_posts = site.posts | where: "starred", true %}
+{% for post in starred_posts %}
+<div class="featured-post">
+    <div class="featured-image">
+        <img src="images/skyline.png" alt="">
+    </div>
+    <h2 class="featured-title"><a href="{{ post.url }}">{{ post.title }}</a></h2>
+</div>
+{% endfor %}


### PR DESCRIPTION
## Summary
- remove the duplicate HTML structure from `index.html` so the page uses the shared layout metadata and scripts
- move the index-specific styling into the shared stylesheet and balance the mobile spacing to keep the layout centered

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68da72f1e9d88321a9736abae0865a6f