### PR TITLE
Reduce mobile overflow on index title

### DIFF
--- a/CSS/styles.css
+++ b/CSS/styles.css
@@ -509,6 +509,31 @@ li {
     border: 1px dotted var(--color-muted);
 }
 
+@media (max-width: 600px) {
+    body {
+        padding: var(--space-xs);
+    }
+
+    .container {
+        padding: 0 var(--space-xs);
+    }
+
+    .title-container {
+        height: auto;
+        padding: var(--space-s) 0;
+    }
+
+    .title {
+        font-size: clamp(1.75rem, 12vw, 2.5rem);
+        letter-spacing: 0.05em;
+    }
+
+    .dotted-box {
+        margin: var(--space-s) 0;
+        padding: var(--space-s);
+    }
+}
+
 /* =========================================================
    Index Page Layout
    ========================================================= */


### PR DESCRIPTION
## Summary
- tighten body and container padding on small screens so index text sits closer to the viewport edges
- adjust the landing title sizing and letter-spacing to prevent clipping on narrow phones
- align dotted box spacing with the more compact mobile layout

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68da770894d483219d2910c9da64da9e