### PR TITLE
Fix mobile title wrapping to prevent auto zoom

### DIFF
--- a/CSS/styles.css
+++ b/CSS/styles.css
@@ -509,6 +509,36 @@ li {
     border: 1px dotted var(--color-muted);
 }
 
+@media (max-width: 600px) {
+    body {
+        padding: var(--space-xs);
+    }
+
+    .container {
+        padding: 0 var(--space-xs);
+    }
+
+    .title-container {
+        height: auto;
+        padding: var(--space-s) 0;
+    }
+
+    .title {
+        font-size: clamp(1.75rem, 12vw, 2.5rem);
+        letter-spacing: 0.03em;
+        line-height: 1.05;
+    }
+
+    .title span {
+        display: block;
+    }
+
+    .dotted-box {
+        margin: var(--space-s) 0;
+        padding: var(--space-s);
+    }
+}
+
 /* =========================================================
    Index Page Layout
    ========================================================= */


### PR DESCRIPTION
## Summary
- stack the split title spans on narrow screens so the landing wordmark can wrap instead of overflowing
- refine mobile letter spacing and line height to keep the heading within the viewport without zooming

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68da770894d483219d2910c9da64da9e