### PR TITLE
Adjust internal link and title color palette

### DIFF
--- a/CSS/styles.css
+++ b/CSS/styles.css
@@ -23,7 +23,9 @@ body, h1, h2, h3, h4, h5, h6, p, figure, blockquote, dl, dd {
     --color-heading: #ffffff;
     --color-heading-hover: #b3b3b3;
     --color-accent: #4A9C6D;
-    --color-link: #e0e0e0;
+    --color-title: #e0b890;
+    --color-link: #8e81a2;
+    --color-link-hover: #6d6380;
     --color-muted: #888888;
     --color-border: #404040;
     --color-blockquote: #c0c0c0;
@@ -61,7 +63,9 @@ body, h1, h2, h3, h4, h5, h6, p, figure, blockquote, dl, dd {
     --color-heading-hover: #555555;
     /* Lighter accent for light mode */
     --color-accent: #6fb88a;
-    --color-link: #333333;
+    --color-title: #c29969;
+    --color-link: #8e81a2;
+    --color-link-hover: #6d6380;
     --color-muted: #666666;
     --color-border: #cccccc;
     --color-blockquote: #555555;
@@ -205,7 +209,6 @@ p {
 /* Content links with dotted underline */
 .post-content a,
 .dotted-box a {
-    color: var(--color-link);
     text-decoration-line: underline;
     text-decoration-style: dotted;
     text-decoration-thickness: 1px;
@@ -216,13 +219,12 @@ p {
 /* Hover state for content links */
 .post-content a:hover,
 .dotted-box a:hover {
-    color: var(--color-muted);
     text-decoration-style: solid;
 }
 
 /* All other links - no underlines by default */
 a {
-    color: var(--color-link);
+    color: inherit;
     text-decoration: none;
     transition: color 0.2s ease;
 }
@@ -231,6 +233,32 @@ a {
 a:focus {
     outline: none;
 
+}
+
+/* Internal link colors */
+a[href]:not([href^="http://"]):not([href^="https://"]):not([href^="//"]):not([href^="mailto:"]):not([href^="tel:"]),
+a[href^="http://croissanthology.com"],
+a[href^="https://croissanthology.com"],
+a[href^="http://www.croissanthology.com"],
+a[href^="https://www.croissanthology.com"],
+a[href^="http://croissanthology.github.io"],
+a[href^="https://croissanthology.github.io"],
+.post-content a,
+.dotted-box a {
+    color: var(--color-link);
+}
+
+/* Internal link hover state */
+a[href]:not([href^="http://"]):not([href^="https://"]):not([href^="//"]):not([href^="mailto:"]):not([href^="tel:"]):hover,
+a[href^="http://croissanthology.com"]:hover,
+a[href^="https://croissanthology.com"]:hover,
+a[href^="http://www.croissanthology.com"]:hover,
+a[href^="https://www.croissanthology.com"]:hover,
+a[href^="http://croissanthology.github.io"]:hover,
+a[href^="https://croissanthology.github.io"]:hover,
+.post-content a:hover,
+.dotted-box a:hover {
+    color: var(--color-link-hover);
 }
 
 /* Special link colors - ONLY on hover */
@@ -267,13 +295,13 @@ a[href*="gwern.net"]:hover {
 }
 
 .post-title a {
-    color: var(--color-accent) !important;
+    color: var(--color-link);
     font-weight: 700 !important;
     border-bottom: none;
 }
 
 .post-title a:hover {
-    opacity: 0.8;
+    color: var(--color-link-hover);
 }
 
 /* =========================================================
@@ -321,7 +349,7 @@ a[href*="gwern.net"]:hover {
     line-height: 0.65;
     float: left;
     margin: 0.2em 0.2em 0 0;
-    color: var(--color-accent);
+    color: var(--color-title);
 }
 
 /* First paragraph in post content */
@@ -332,7 +360,7 @@ a[href*="gwern.net"]:hover {
     line-height: 0.65;
     float: left;
     margin: 0.2em 0.2em 0 0;
-    color: var(--color-accent);
+    color: var(--color-title);
 }
 
 /* =========================================================
@@ -441,11 +469,11 @@ li {
 }
 
 .title-white {
-    color: var(--color-heading);
+    color: var(--color-title);
 }
 
 .title-green {
-    color: var(--color-accent);
+    color: var(--color-title);
 }
 
 /* Image hover effect - simple fade */

--- a/player.html
+++ b/player.html
@@ -9,7 +9,7 @@
         :root {
             --background-color: #1a1a1a;
             --text-color: #e0e0e0;
-            --accent-color: #4A9C6D;
+            --accent-color: #e0b890;
             --main-width: min(800px, 90vw);
         }
 
@@ -56,7 +56,7 @@
             line-height: 0.8;
             padding-top: 0.1em;
             padding-right: 0.1em;
-            color: #4A9C6D;
+            color: var(--accent-color);
         }
 
         .dotted-box {


### PR DESCRIPTION
## Summary
- align the site title and dropcaps with the new brass-tan palette across light and dark themes
- update internal link colors and hover treatments while keeping external brand hover overrides intact

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68db168bd0e0832196260ee18f179743