### PR TITLE
Adjust heading and ToC link colors for theme

### DIFF
--- a/CSS/styles.css
+++ b/CSS/styles.css
@@ -190,6 +190,10 @@ h1::after, h2::after, h3::after, h4::after, h5::after {
     text-decoration-style: solid;
 }
 
+.post-content :is(h1, h2, h3, h4, h5, h6) > .heading-link {
+    color: var(--color-heading);
+}
+
 .post-content .heading-link:hover,
 .post-content .heading-link:focus,
 .heading-link:hover,
@@ -242,7 +246,7 @@ a:focus {
 }
 
 /* Internal link colors */
-a[href]:not([href^="http://"]):not([href^="https://"]):not([href^="//"]):not([href^="mailto:"]):not([href^="tel:"]),
+a[href]:not([href^="http://"]):not([href^="https://"]):not([href^="//"]):not([href^="mailto:"]):not([href^="tel:"]):not(.heading-link):not(.toc-link),
 a[href^="http://croissanthology.com"],
 a[href^="https://croissanthology.com"],
 a[href^="http://www.croissanthology.com"],
@@ -257,7 +261,7 @@ a[href^="https://croissanthology.github.io"],
 }
 
 /* Internal link hover state */
-a[href]:not([href^="http://"]):not([href^="https://"]):not([href^="//"]):not([href^="mailto:"]):not([href^="tel:"]):hover,
+a[href]:not([href^="http://"]):not([href^="https://"]):not([href^="//"]):not([href^="mailto:"]):not([href^="tel:"]):not(.heading-link):not(.toc-link):hover,
 a[href^="http://croissanthology.com"]:hover,
 a[href^="https://croissanthology.com"]:hover,
 a[href^="http://www.croissanthology.com"]:hover,

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -155,7 +155,7 @@ layout: default
 
 .post-toc a {
     text-decoration: none;
-    color: inherit;
+    color: var(--color-heading);
 }
 
 .post-toc .toc-number {

--- a/javascript/toc.js
+++ b/javascript/toc.js
@@ -38,6 +38,7 @@ document.addEventListener('DOMContentLoaded', () => {
     li.style.marginLeft = depth * 16 + 'px';
 
     const a = document.createElement('a');
+    a.className = 'toc-link';
     a.href = '#' + h.id;
     const numSpan = document.createElement('span');
     numSpan.className = 'toc-number';


### PR DESCRIPTION
## Summary
- ensure heading permalinks and generated table of contents links adopt the theme heading color instead of internal link lavender
- tag generated table of contents anchors with a class so they can be excluded from default internal link styling
- keep table of contents entries aligned with heading color tokens for both light and dark themes

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68dbfeba8630832195c65c3ad6a4b92b