### PR TITLE
Adjust mobile spacing for index intro text

### DIFF
--- a/CSS/styles.css
+++ b/CSS/styles.css
@@ -713,7 +713,8 @@ li {
     .dotted-box {
         border: none;
         border-bottom: 1px dotted var(--color-border);
-        padding-inline: var(--space-xs);
+        margin-inline: 0;
+        padding-inline: calc(var(--space-xs) / 2);
     }
 
     .featured-post {


### PR DESCRIPTION
## Summary
- reduce the intro dotted box's horizontal padding on mobile so it aligns with the post list margins

## Testing
- bundle install *(fails: Net::HTTPClientException 403 "Forbidden")*


------
https://chatgpt.com/codex/tasks/task_e_68de8f26b178832197ac298a450a4bea